### PR TITLE
Docker compose example and changes to reduce httpd chatter in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN apt-get update && apt-get -y install \
     wget \
     zlib1g-dev
 
+# time zone
+RUN apt-get install -y tzdata
+
 # add the CPAN CGI module
 RUN cpanm CGI 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,9 @@ RUN sed -i.bak -e'/<\/VirtualHost>/ i \
 COPY docker_scripts/apache.sh /etc/service/apache2/run 
 RUN chmod +x /etc/service/apache2/run
 
+# Set the ServerName directive to suppress Apache error
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
 #
 # create crontab from wvnetflow commands
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,11 @@ services:
     container_name: wvnr_img
     volumes:
       - /path/to/your/netflow:/opt/netflow # Mount netflow data to a volume
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     ports:
       - "83:80"
       - "2055:2055/udp"
+    environment:
+      - TZ=America/New_York
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  wvnr:
+    build:
+      context: .
+    image: wvnr_img
+    container_name: wvnr_img
+    volumes:
+      - /path/to/your/netflow:/opt/netflow # Mount netflow data to a volume
+    ports:
+      - "83:80"
+      - "2055:2055/udp"
+    restart: unless-stopped

--- a/docker_scripts/apache.sh
+++ b/docker_scripts/apache.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # apache control script
-/usr/sbin/apache2ctl -D FOREGROUND &
+/usr/sbin/apache2ctl -D FOREGROUND

--- a/docker_scripts/newcron
+++ b/docker_scripts/newcron
@@ -24,8 +24,13 @@
 0 0 1 * * /usr/local/bin/sudo mv -f /var/log/flowd2ft-2055.log /var/log/flowd2ft-2055.old
 0 0 1 * * /usr/local/bin/sudo mv -f /var/log/monFlows.log /var/log/monFlows.old
 
-# Every minute, write a log entry
-* * * * * echo "Cron test"  2>&1
+# every minute, write a log entry
+# * * * * * echo "Cron test"  2>&1
+# uncomment if you need this for testing
 
+# every hour, delete the lock file if it exists
+0 * * * * rm -f /opt/netflow/tmp/flowage.lck
+# stale lock files will cause flowage.pl to stop running completely
 
 # LAST LINE - crontab files need a CRLF at the end
+


### PR DESCRIPTION
I added a sample docker-compose.yml file. In my environment, I mounted an external drive to /opt/netflow since there is limited space inside the LXC where this service is running.

Additionally, I removed the `&` from the end of the apache2ctl command because this was repeatedly trying to start the httpd service and outputting a message to the Docker logs. 

I also added a ServerName directive to the apache2.conf file to prevent an error from being raised.